### PR TITLE
Allow spaces in sentence builder

### DIFF
--- a/src/i18n/translations/de.ts
+++ b/src/i18n/translations/de.ts
@@ -12,6 +12,7 @@ export const de = {
       invalidWord: "Ungültiges Wort",
       cantUseTargetWord: "Du kannst das Zielwort nicht verwenden",
       lettersOnly: "Bitte nur Buchstaben verwenden",
+      singleWordOnly: "Bitte nur ein Wort eingeben",
       leaveGameTitle: "Spiel verlassen?",
       leaveGameDescription: "Dein aktueller Fortschritt geht verloren. Bist du sicher, dass du das Spiel verlassen möchtest?",
       cancel: "Abbrechen",

--- a/src/i18n/translations/en.ts
+++ b/src/i18n/translations/en.ts
@@ -12,91 +12,90 @@ export const en = {
       invalidWord: "Invalid Word",
       cantUseTargetWord: "You can't use the target word",
       lettersOnly: "Please use letters only",
+      singleWordOnly: "Please enter only one word",
       leaveGameTitle: "Leave Game?",
       leaveGameDescription: "Your current progress will be lost. Are you sure you want to leave?",
       cancel: "Cancel",
       confirm: "Confirm",
       describeWord: "Your goal is to describe the word"
     },
-  leaderboard: {
-    title: "High Scores",
-    yourScore: "Your Score",
-    roundCount: "rounds",
-    wordsPerRound: "words per round",
-    enterName: "Enter your name",
-    submitting: "Submitting...",
-    submit: "Submit Score",
-    rank: "Rank",
-    player: "Player",
-    roundsColumn: "Rounds",
-    avgWords: "Avg. Words",
-    noScores: "No scores yet",
-    previous: "Previous",
-    next: "Next",
-    error: {
-      invalidName: "Please enter a valid name",
-      noRounds: "You need to complete at least one round",
-      alreadySubmitted: "Score already submitted",
-      newHighScore: "New High Score!",
-      beatRecord: "You beat your previous record of {score}!",
-      notHigher: "Score of {current} not higher than your best of {best}",
-      submitError: "Error submitting score"
-    }
-  },
-  guess: {
-    title: "AI's Guess",
-    goalDescription: "Your goal was to describe the word",
-    providedDescription: "You provided the description",
-    aiGuessedDescription: "Based on your description, the AI guessed",
-    correct: "This is right!",
-    incorrect: "This is wrong.",
-    nextRound: "Next Round",
-    playAgain: "Play Again",
-    viewLeaderboard: "Save your score",
-    cheatingDetected: "Cheating detected!"
-  },
-  themes: {
-    title: "Choose a Theme",
-    subtitle: "Select a theme for the word the AI will try to guess",
-    standard: "Standard",
-    technology: "Technology",
-    sports: "Sports",
-    food: "Food",
-    custom: "Custom Theme",
-    customPlaceholder: "Enter your custom theme...",
-    continue: "Continue",
-    generating: "Generating...",
-    pressKey: "Press"
-  },
-  welcome: {
-    title: "Think in Sync",
-    subtitle: "Build sentences together and let AI guess your word!",
-    startButton: "Start Game",
-    howToPlay: "How to Play",
-    leaderboard: "Leaderboard",
-    credits: "Created during the",
-    helpWin: "Help us win by",
-    onHuggingface: "Liking on Huggingface"
-  },
-  howToPlay: {
-    setup: {
-      title: "Setup",
-      description: "Choose a theme and get a secret word that the AI will try to guess."
+    leaderboard: {
+      title: "High Scores",
+      yourScore: "Your Score",
+      roundCount: "rounds",
+      wordsPerRound: "words per round",
+      enterName: "Enter your name",
+      submitting: "Submitting...",
+      submit: "Submit Score",
+      rank: "Rank",
+      player: "Player",
+      roundsColumn: "Rounds",
+      avgWords: "Avg. Words",
+      noScores: "No scores yet",
+      previous: "Previous",
+      next: "Next",
+      error: {
+        invalidName: "Please enter a valid name",
+        noRounds: "You need to complete at least one round",
+        alreadySubmitted: "Score already submitted",
+        newHighScore: "New High Score!",
+        beatRecord: "You beat your previous record of {score}!",
+        notHigher: "Score of {current} not higher than your best of {best}",
+        submitError: "Error submitting score"
+      }
     },
-    goal: {
-      title: "Goal",
-      description: "Build sentences together with the AI that describe your word without using it directly."
+    guess: {
+      title: "AI's Guess",
+      goalDescription: "Your goal was to describe the word",
+      providedDescription: "You provided the description",
+      aiGuessedDescription: "Based on your description, the AI guessed",
+      correct: "This is right!",
+      incorrect: "This is wrong.",
+      nextRound: "Next Round",
+      playAgain: "Play Again",
+      viewLeaderboard: "Save your score",
+      cheatingDetected: "Cheating detected!"
     },
-    rules: {
-      title: "Rules",
-      items: [
-        "Take turns adding words to build descriptive sentences",
-        "Don't use the secret word or its variations",
-        "Try to be creative and descriptive",
-        "The AI will try to guess your word after each sentence"
-      ]
+    themes: {
+      title: "Choose a Theme",
+      subtitle: "Select a theme for the word the AI will try to guess",
+      standard: "Standard",
+      technology: "Technology",
+      sports: "Sports",
+      food: "Food",
+      custom: "Custom Theme",
+      customPlaceholder: "Enter your custom theme...",
+      continue: "Continue",
+      generating: "Generating...",
+      pressKey: "Press"
+    },
+    welcome: {
+      title: "Think in Sync",
+      subtitle: "Build sentences together and let AI guess your word!",
+      startButton: "Start Game",
+      howToPlay: "How to Play",
+      leaderboard: "Leaderboard",
+      credits: "Created during the",
+      helpWin: "Help us win by",
+      onHuggingface: "Liking on Huggingface"
+    },
+    howToPlay: {
+      setup: {
+        title: "Setup",
+        description: "Choose a theme and get a secret word that the AI will try to guess."
+      },
+      goal: {
+        title: "Goal",
+        description: "Build sentences together with the AI that describe your word without using it directly."
+      },
+      rules: {
+        title: "Rules",
+        items: [
+          "Take turns adding words to build descriptive sentences",
+          "Don't use the secret word or its variations",
+          "Try to be creative and descriptive",
+          "The AI will try to guess your word after each sentence"
+        ]
+      }
     }
-  }
 };
-
-

--- a/src/i18n/translations/es.ts
+++ b/src/i18n/translations/es.ts
@@ -12,90 +12,90 @@ export const es = {
       invalidWord: "Palabra inválida",
       cantUseTargetWord: "No puedes usar la palabra objetivo",
       lettersOnly: "Por favor, usa solo letras",
+      singleWordOnly: "Por favor, ingresa solo una palabra",
       leaveGameTitle: "¿Salir del juego?",
       leaveGameDescription: "Tu progreso actual se perderá. ¿Estás seguro de que quieres salir?",
       cancel: "Cancelar",
       confirm: "Confirmar",
       describeWord: "Tu objetivo es describir la palabra"
     },
-  leaderboard: {
-    title: "Puntuaciones Más Altas",
-    yourScore: "Tu Puntuación",
-    roundCount: "rondas",
-    wordsPerRound: "palabras por ronda",
-    enterName: "Ingresa tu nombre",
-    submitting: "Enviando...",
-    submit: "Enviar Puntuación",
-    rank: "Posición",
-    player: "Jugador",
-    roundsColumn: "Rondas",
-    avgWords: "Prom. Palabras",
-    noScores: "Aún no hay puntuaciones",
-    previous: "Anterior",
-    next: "Siguiente",
-    error: {
-      invalidName: "Por favor, ingresa un nombre válido",
-      noRounds: "Debes completar al menos una ronda",
-      alreadySubmitted: "Puntuación ya enviada",
-      newHighScore: "¡Nueva Puntuación Más Alta!",
-      beatRecord: "¡Has superado tu récord anterior de {score}!",
-      notHigher: "Puntuación de {current} no superior a tu mejor de {best}",
-      submitError: "Error al enviar la puntuación"
-    }
-  },
-  guess: {
-    title: "Suposición de la IA",
-    goalDescription: "Tu objetivo era describir la palabra",
-    providedDescription: "Proporcionaste la descripción",
-    aiGuessedDescription: "Basado en tu descripción, la IA adivinó",
-    correct: "¡Esto es correcto!",
-    incorrect: "Esto es incorrecto.",
-    nextRound: "Siguiente Ronda",
-    playAgain: "Jugar de Nuevo",
-    viewLeaderboard: "Ver Clasificación",
-    cheatingDetected: "¡Trampa detectada!"
-  },
-  themes: {
-    title: "Elige un Tema",
-    subtitle: "Selecciona un tema para la palabra que la IA intentará adivinar",
-    standard: "Estándar",
-    technology: "Tecnología",
-    sports: "Deportes",
-    food: "Comida",
-    custom: "Tema Personalizado",
-    customPlaceholder: "Ingresa tu tema personalizado...",
-    continue: "Continuar",
-    generating: "Generando...",
-    pressKey: "Presiona"
-  },
-  welcome: {
-    title: "Think in Sync",
-    subtitle: "¡Construye frases juntos y deja que la IA adivine tu palabra!",
-    startButton: "Comenzar Juego",
-    howToPlay: "Cómo Jugar",
-    leaderboard: "Clasificación",
-    credits: "Creado durante el",
-    helpWin: "Ayúdanos a ganar",
-    onHuggingface: "Dando me gusta en Huggingface"
-  },
-  howToPlay: {
-    setup: {
-      title: "Preparación",
-      description: "Elige un tema y obtén una palabra secreta que la IA intentará adivinar."
+    leaderboard: {
+      title: "Puntuaciones Más Altas",
+      yourScore: "Tu Puntuación",
+      roundCount: "rondas",
+      wordsPerRound: "palabras por ronda",
+      enterName: "Ingresa tu nombre",
+      submitting: "Enviando...",
+      submit: "Enviar Puntuación",
+      rank: "Posición",
+      player: "Jugador",
+      roundsColumn: "Rondas",
+      avgWords: "Prom. Palabras",
+      noScores: "Aún no hay puntuaciones",
+      previous: "Anterior",
+      next: "Siguiente",
+      error: {
+        invalidName: "Por favor, ingresa un nombre válido",
+        noRounds: "Debes completar al menos una ronda",
+        alreadySubmitted: "Puntuación ya enviada",
+        newHighScore: "¡Nueva Puntuación Más Alta!",
+        beatRecord: "¡Has superado tu récord anterior de {score}!",
+        notHigher: "Puntuación de {current} no superior a tu mejor de {best}",
+        submitError: "Error al enviar la puntuación"
+      }
     },
-    goal: {
-      title: "Objetivo",
-      description: "Construye frases junto con la IA que describan tu palabra sin usarla directamente."
+    guess: {
+      title: "Suposición de la IA",
+      goalDescription: "Tu objetivo era describir la palabra",
+      providedDescription: "Proporcionaste la descripción",
+      aiGuessedDescription: "Basado en tu descripción, la IA adivinó",
+      correct: "¡Esto es correcto!",
+      incorrect: "Esto es incorrecto.",
+      nextRound: "Siguiente Ronda",
+      playAgain: "Jugar de Nuevo",
+      viewLeaderboard: "Ver Clasificación",
+      cheatingDetected: "¡Trampa detectada!"
     },
-    rules: {
-      title: "Reglas",
-      items: [
-        "Añade palabras por turnos para construir frases descriptivas",
-        "No uses la palabra secreta o sus variaciones",
-        "Sé creativo y descriptivo",
-        "La IA intentará adivinar tu palabra después de cada frase"
-      ]
+    themes: {
+      title: "Elige un Tema",
+      subtitle: "Selecciona un tema para la palabra que la IA intentará adivinar",
+      standard: "Estándar",
+      technology: "Tecnología",
+      sports: "Deportes",
+      food: "Comida",
+      custom: "Tema Personalizado",
+      customPlaceholder: "Ingresa tu tema personalizado...",
+      continue: "Continuar",
+      generating: "Generando...",
+      pressKey: "Presiona"
+    },
+    welcome: {
+      title: "Think in Sync",
+      subtitle: "¡Construye frases juntos y deja que la IA adivine tu palabra!",
+      startButton: "Comenzar Juego",
+      howToPlay: "Cómo Jugar",
+      leaderboard: "Clasificación",
+      credits: "Creado durante el",
+      helpWin: "Ayúdanos a ganar",
+      onHuggingface: "Dando me gusta en Huggingface"
+    },
+    howToPlay: {
+      setup: {
+        title: "Preparación",
+        description: "Elige un tema y obtén una palabra secreta que la IA intentará adivinar."
+      },
+      goal: {
+        title: "Objetivo",
+        description: "Construye frases junto con la IA que describan tu palabra sin usarla directamente."
+      },
+      rules: {
+        title: "Reglas",
+        items: [
+          "Añade palabras por turnos para construir frases descriptivas",
+          "No uses la palabra secreta o sus variaciones",
+          "Sé creativo y descriptivo",
+          "La IA intentará adivinar tu palabra después de cada frase"
+        ]
+      }
     }
-  }
 };
-

--- a/src/i18n/translations/fr.ts
+++ b/src/i18n/translations/fr.ts
@@ -11,6 +11,7 @@ export const fr = {
       invalidWord: "Mot invalide",
       cantUseTargetWord: "Vous ne pouvez pas utiliser le mot cible",
       lettersOnly: "Veuillez utiliser uniquement des lettres",
+      singleWordOnly: "Veuillez entrer un seul mot",
       leaveGameTitle: "Quitter le jeu ?",
       leaveGameDescription: "Votre progression actuelle sera perdue. Êtes-vous sûr de vouloir quitter ?",
       cancel: "Annuler",

--- a/src/i18n/translations/it.ts
+++ b/src/i18n/translations/it.ts
@@ -12,6 +12,7 @@ export const it = {
       invalidWord: "Parola non valida",
       cantUseTargetWord: "Non puoi usare la parola obiettivo",
       lettersOnly: "Usa solo lettere",
+      singleWordOnly: "Inserisci una sola parola",
       leaveGameTitle: "Lasciare il gioco?",
       leaveGameDescription: "I tuoi progressi attuali andranno persi. Sei sicuro di voler uscire?",
       cancel: "Annulla",


### PR DESCRIPTION
Updated the SentenceBuilder component to allow spaces in the input field. The Add Word and Make Guess buttons are now greyed out when spaces are detected, and a red input validation symbol is displayed along with a message indicating that only one word can be entered at a time. Added necessary translations for the new validation messages. [skip gpt_engineer]